### PR TITLE
Remove unneccessary 'groups' parameter

### DIFF
--- a/tasks/create_containers.yml
+++ b/tasks/create_containers.yml
@@ -24,7 +24,6 @@
     - add_host:
         name: '{{ host }}'
         ansible_host: '{{ job_id ~ host }}'
-        groups: '{{ hostvars[host]["group_names"] }}'
         ansible_connection: docker
         ansible_user: root
         inventory_dir: "{{ hostvars[host]['inventory_dir'] }}"


### PR DESCRIPTION
`groups` parameter was required for Ansible <= 2.4.2 in order to workaround ansible/ansible#33878. This parameter is now useless.

Closes #5