### PR TITLE
Remove unnecessary 'run_once' keywords

### DIFF
--- a/tasks/create_containers.yml
+++ b/tasks/create_containers.yml
@@ -19,7 +19,6 @@
           - /run/lock
         volumes:
           - /sys/fs/cgroup:/sys/fs/cgroup:ro
-      run_once: true
 
     - add_host:
         name: '{{ host }}'
@@ -28,4 +27,3 @@
         ansible_connection: docker
         ansible_user: root
         inventory_dir: "{{ hostvars[host]['inventory_dir'] }}"
-      run_once: true


### PR DESCRIPTION
Tasks aren't in a loop, `run_once` doesn't change anything here.

Closes #2