### PR TITLE
Add options to bind ports and volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ communicate, Docker default network is used if not specified.
 * `boot_docker_host` name and hostname of the container, by default
 `inventory_hostname` is used (and available using `host` variable).
 * `boot_docker_command`: command to execute when the container starts.
+* `boot_docker_ports`: list of published ports following the Docker CLI syntax
+  (`['8080:80']`, etc.).
+* `boot_docker_volumes`: list of volumes to bind following the Docker CLI syntax
+  (`['/host:/container[:ro|rw]']`).
 
 Following variable is required:
 * `boot_docker_image` is an available docker image. When this variable isn't
@@ -37,6 +41,10 @@ This role supposes the following inventory :
 ```ini
 [python]
 app1.example boot_docker_image=registry.fedoraproject.org/f26/python3
+
+[python:vars]
+boot_docker_ports="['8080:80']"
+boot_docker_volumes="['/tmp/data:/data:ro']"
 
 [debian]
 app2.example boot_docker_image=debian:stable

--- a/README.md
+++ b/README.md
@@ -42,15 +42,23 @@ This role supposes the following inventory :
 [python]
 app1.example boot_docker_image=registry.fedoraproject.org/f26/python3
 
-[python:vars]
-boot_docker_ports="['8080:80']"
-boot_docker_volumes="['/tmp/data:/data:ro']"
-
 [debian]
 app2.example boot_docker_image=debian:stable
 
 [container_not_created]
 app3.example
+```
+
+You should then use `host_vars` or `group_vars` to define other variables :
+
+```yaml
+# host_vars/debian.yml
+
+boot_docker_command: sleep infinity
+boot_docker_volumes:
+  - /tmp/data:/mnt/data:ro
+boot_docker_ports:
+  - 8080:80
 ```
 
 ### Playbook

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -14,6 +14,10 @@
         name: container1
         boot_docker_image: alpine
         boot_docker_command: tail -F /dev/null
+        boot_docker_ports:
+          - 8080:80
+        boot_docker_volumes:
+          - /tmp:/tmp/host_tmp:ro
       changed_when: false
     - name: update inventory (add anotherhost)
       add_host:

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -14,3 +14,15 @@ def test_containers():
 
     # Check network has been created
     localhost.check_output('docker network inspect ansible-boot-docker-net')
+
+    cmd = localhost.run(
+        "docker inspect -f '{{.HostConfig.PortBindings}}' container1-test"
+    )
+
+    assert 'map[80/tcp:[{0.0.0.0 8080}]]' in cmd.stdout
+
+    cmd = localhost.run(
+        "docker inspect -f '{{.HostConfig.Binds}}' container1-test"
+    )
+
+    assert '/tmp:/tmp/host_tmp:ro' in cmd.stdout

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -1,9 +1,9 @@
 import testinfra
 
+localhost = testinfra.get_host('local://')
+
 
 def test_containers():
-
-    localhost = testinfra.get_host('local://')
 
     # Check container exists
     localhost.check_output('docker container inspect container1-test')
@@ -15,12 +15,16 @@ def test_containers():
     # Check network has been created
     localhost.check_output('docker network inspect ansible-boot-docker-net')
 
+
+def test_port_bindings():
     cmd = localhost.run(
         "docker inspect -f '{{.HostConfig.PortBindings}}' container1-test"
     )
 
     assert 'map[80/tcp:[{0.0.0.0 8080}]]' in cmd.stdout
 
+
+def test_volumes_binds():
     cmd = localhost.run(
         "docker inspect -f '{{.HostConfig.Binds}}' container1-test"
     )

--- a/tasks/create_containers.yml
+++ b/tasks/create_containers.yml
@@ -6,7 +6,7 @@
       docker_container:
         name: '{{ boot_docker_host|default(host) }}'
         hostname: '{{ boot_docker_host|default(host) }}'
-        command: '{{ hostvars[host]["boot_docker_command"]|default(omit) }}'
+        command: '{{ hostvars[host]["boot_docker_command"]|default(omit) }}'
         image: '{{ hostvars[host]["boot_docker_image"] }}'
         networks:
           - name: "{{ boot_docker_network|default(omit) }}"
@@ -18,8 +18,8 @@
           - /tmp
           - /run
           - /run/lock
-        volumes:
-          - /sys/fs/cgroup:/sys/fs/cgroup:ro
+        volumes: '{{ hostvars[host]["boot_docker_volumes"]|default([]) + ["/sys/fs/cgroup:/sys/fs/cgroup:ro"] }}'
+        ports: '{{ hostvars[host]["boot_docker_ports"]|default(omit) }}'
 
     - name: update inventory
       add_host:

--- a/tasks/create_containers.yml
+++ b/tasks/create_containers.yml
@@ -18,7 +18,8 @@
           - /tmp
           - /run
           - /run/lock
-        volumes: '{{ hostvars[host]["boot_docker_volumes"]|default([]) + ["/sys/fs/cgroup:/sys/fs/cgroup:ro"] }}'
+        volumes: '{{ hostvars[host]["boot_docker_volumes"]|default([])
+        + ["/sys/fs/cgroup:/sys/fs/cgroup:ro"] }}'
         ports: '{{ hostvars[host]["boot_docker_ports"]|default(omit) }}'
 
     - name: update inventory

--- a/tasks/create_containers.yml
+++ b/tasks/create_containers.yml
@@ -18,7 +18,7 @@
           - /tmp
           - /run
           - /run/lock
-        volumes: '{{ hostvars[host]["boot_docker_volumes"]|default([]) }} + {{ ["/sys/fs/cgroup:/sys/fs/cgroup:ro"] }}'
+        volumes: '{{ hostvars[host]["boot_docker_volumes"]|default([]) + ["/sys/fs/cgroup:/sys/fs/cgroup:ro"] }}'
         ports: '{{ hostvars[host]["boot_docker_ports"]|default(omit) }}'
 
     - name: update inventory

--- a/tasks/create_containers.yml
+++ b/tasks/create_containers.yml
@@ -18,7 +18,7 @@
           - /tmp
           - /run
           - /run/lock
-        volumes: '{{ hostvars[host]["boot_docker_volumes"]|default([]) + ["/sys/fs/cgroup:/sys/fs/cgroup:ro"] }}'
+        volumes: '{{ hostvars[host]["boot_docker_volumes"]|default([]) }} + {{ ["/sys/fs/cgroup:/sys/fs/cgroup:ro"] }}'
         ports: '{{ hostvars[host]["boot_docker_ports"]|default(omit) }}'
 
     - name: update inventory


### PR DESCRIPTION
Motivations:
* Give more options to role user by adding ways to publish ports and to bind
  more volumes when creating containers with ansible-boot-docker.

Modifications:
* Add `boot_docker_ports` and `boot_docker_volumes` host parameters which are
  then used when creating the host.
* Add documentation for those parameters.