### PR TITLE
Add network options to the role parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Role Variables
 Following variables are optional:
 * `boot_docker_network`: name the docker network used by the hosts to
 communicate, Docker default network is used if not specified.
+* `boot_docker_network_aliases`: list of network aliases for the host
+  on the network. Works only if used with `boot_docker_network`
 * `boot_docker_host` name and hostname of the container, by default
 `inventory_hostname` is used (and available using `host` variable).
 * `boot_docker_command`: command to execute when the container starts.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,13 @@ Following variables are optional:
 * `boot_docker_network`: name the docker network used by the hosts to
 communicate, Docker default network is used if not specified.
 * `boot_docker_network_aliases`: list of network aliases for the host
-  on the network. Works only if used with `boot_docker_network`
+  on the network. Works only if used with `boot_docker_network`.
+* `boot_docker_network_ipv4`: ipv4 address of the container in the
+  network. Works only if used with `boot_docker_network`.
+* `boot_docker_network_ipv6`: ipv6 address of the container in the
+  network. Works only if used with `boot_docker_network`.
+* `boot_docker_purge_networks`: Remove container from other
+  networks when using `boot_docker_network`. Defaults to `true`.
 * `boot_docker_host` name and hostname of the container, by default
 `inventory_hostname` is used (and available using `host` variable).
 * `boot_docker_command`: command to execute when the container starts.

--- a/README.md
+++ b/README.md
@@ -20,11 +20,14 @@ Following variables are optional:
 * `boot_docker_network`: name the docker network used by the hosts to
 communicate, Docker default network is used if not specified.
 * `boot_docker_network_aliases`: list of network aliases for the host
-  on the network. Works only if used with `boot_docker_network`.
+  on the network. Works only if used with
+  `boot_docker_network`. Defaults to no aliases.
 * `boot_docker_network_ipv4`: ipv4 address of the container in the
-  network. Works only if used with `boot_docker_network`.
+  network. Works only if used with `boot_docker_network`. Defaults to
+  let Docker choose an IP.
 * `boot_docker_network_ipv6`: ipv6 address of the container in the
-  network. Works only if used with `boot_docker_network`.
+  network. Works only if used with `boot_docker_network`. Defaults to
+  let Docker choose an IP.
 * `boot_docker_purge_networks`: Remove container from other
   networks when using `boot_docker_network`. Defaults to `true`.
 * `boot_docker_host` name and hostname of the container, by default

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+boot_docker_network_aliases: []
+boot_docker_purge_networks: true
+boot_docker_network_ipv4: ""
+boot_docker_network_ipv6: ""

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
 boot_docker_network_aliases: []
 boot_docker_purge_networks: true
-boot_docker_network_ipv4: ""
-boot_docker_network_ipv6: ""
+boot_docker_network_ipv4: null
+boot_docker_network_ipv6: null

--- a/tasks/create_containers.yml
+++ b/tasks/create_containers.yml
@@ -10,8 +10,10 @@
         image: '{{ hostvars[host]["boot_docker_image"] }}'
         networks:
           - name: "{{ boot_docker_network|default(omit) }}"
+            ipv4_address: "{{ boot_docker_network_ipv4|default(omit) }}"
+            ipv6_address: "{{ boot_docker_network_ipv6|default(omit) }}"
             aliases: "{{ boot_docker_network_aliases|default([]) }}"
-        purge_networks: true
+        purge_networks: "{{ boot_docker_purge_networks|default(true) }}"
         # These are non privileged containers running systemctl, see:
         # https://developers.redhat.com/blog/2016/09/13/running-systemd-in-a-non-privileged-container/
         security_opts: seccomp=unconfined  # required on Debian

--- a/tasks/create_containers.yml
+++ b/tasks/create_containers.yml
@@ -10,8 +10,9 @@
         image: '{{ hostvars[host]["boot_docker_image"] }}'
         networks:
           - name: "{{ boot_docker_network|default(omit) }}"
+            aliases: "{{ boot_docker_network_aliases|default(omit) }}"
         purge_networks: true
-        # These are non privileged container running systemctl, see:
+        # These are non privileged containers running systemctl, see:
         # https://developers.redhat.com/blog/2016/09/13/running-systemd-in-a-non-privileged-container/
         security_opts: seccomp=unconfined  # required on Debian
         tmpfs:

--- a/tasks/create_containers.yml
+++ b/tasks/create_containers.yml
@@ -10,10 +10,10 @@
         image: '{{ hostvars[host]["boot_docker_image"] }}'
         networks:
           - name: "{{ boot_docker_network|default(omit) }}"
-            ipv4_address: "{{ boot_docker_network_ipv4|default(omit) }}"
-            ipv6_address: "{{ boot_docker_network_ipv6|default(omit) }}"
-            aliases: "{{ boot_docker_network_aliases|default([]) }}"
-        purge_networks: "{{ boot_docker_purge_networks|default(true) }}"
+            ipv4_address: "{{ boot_docker_network_ipv4 }}"
+            ipv6_address: "{{ boot_docker_network_ipv6 }}"
+            aliases: "{{ boot_docker_network_aliases }}"
+        purge_networks: "{{ boot_docker_purge_networks }}"
         # These are non privileged containers running systemctl, see:
         # https://developers.redhat.com/blog/2016/09/13/running-systemd-in-a-non-privileged-container/
         security_opts: seccomp=unconfined  # required on Debian

--- a/tasks/create_containers.yml
+++ b/tasks/create_containers.yml
@@ -10,7 +10,7 @@
         image: '{{ hostvars[host]["boot_docker_image"] }}'
         networks:
           - name: "{{ boot_docker_network|default(omit) }}"
-            aliases: "{{ boot_docker_network_aliases|default(omit) }}"
+            aliases: "{{ boot_docker_network_aliases|default([]) }}"
         purge_networks: true
         # These are non privileged containers running systemctl, see:
         # https://developers.redhat.com/blog/2016/09/13/running-systemd-in-a-non-privileged-container/


### PR DESCRIPTION
Motivation: 

* Add possibility to use network aliases when creating containers inside a network with the role.  
* Add possibility to set ipv4 or ipv6 of the container when creating containers inside a network with the role.

Modification:

* Add optional options `boot_docker_network_aliases`, `boot_docker_network_ipv4|6` and `boot_docker_purge_networks` which are forwarded to `docker_container` Ansible module.
