### PR TITLE
Fix host-specific parameter usage

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,2 @@
 ---
-boot_docker_network_aliases: []
 boot_docker_purge_networks: true
-boot_docker_network_ipv4: null
-boot_docker_network_ipv6: null

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -19,6 +19,25 @@
         boot_docker_volumes:
           - /tmp:/tmp/host_tmp:ro
       changed_when: false
+    - name: update inventory (add container2)
+      add_host:
+        name: container2
+        boot_docker_image: alpine
+        boot_docker_command: tail -F /dev/null
+        boot_docker_network_aliases:
+          - container2.test
+          - app2
+      changed_when: false
+    - name: update inventory (add container3)
+      add_host:
+        name: container3
+        boot_docker_image: alpine
+        boot_docker_command: tail -F /dev/null
+        boot_docker_network_aliases:
+          - container3.test
+          - app3
+      changed_when: false
+
     - name: update inventory (add anotherhost)
       add_host:
         name: anotherhost

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -30,3 +30,23 @@ def test_volumes_binds():
     )
 
     assert '/tmp:/tmp/host_tmp:ro' in cmd.stdout
+
+
+def test_containers_aliases():
+    cmd = localhost.run(
+        """docker inspect -f \
+        '{{range .NetworkSettings.Networks}}{{.Aliases}}{{end}}' \
+        container2-test"""
+    )
+
+    assert 'container2.test' in cmd.stdout
+    assert 'app2' in cmd.stdout
+
+    cmd = localhost.run(
+         """docker inspect -f \
+         '{{range .NetworkSettings.Networks}}{{.Aliases}}{{end}}' \
+         container3-test"""
+    )
+
+    assert 'container3.test' in cmd.stdout
+    assert 'app3' in cmd.stdout

--- a/tasks/create_containers.yml
+++ b/tasks/create_containers.yml
@@ -10,9 +10,12 @@
         image: '{{ hostvars[host]["boot_docker_image"] }}'
         networks:
           - name: "{{ boot_docker_network|default(omit) }}"
-            ipv4_address: "{{ boot_docker_network_ipv4 }}"
-            ipv6_address: "{{ boot_docker_network_ipv6 }}"
-            aliases: "{{ boot_docker_network_aliases }}"
+            ipv4_address: "{{ hostvars[host]['boot_docker_network_ipv4']\
+            |default(none) }}"
+            ipv6_address: "{{ hostvars[host]['boot_docker_network_ipv6']\
+            |default(none) }}"
+            aliases: "{{ hostvars[host]['boot_docker_network_aliases']\
+            |default([]) }}"
         purge_networks: "{{ boot_docker_purge_networks }}"
         # These are non privileged containers running systemctl, see:
         # https://developers.redhat.com/blog/2016/09/13/running-systemd-in-a-non-privileged-container/


### PR DESCRIPTION
Motivation:
* IP addresses and aliases variables should be specific to each host, not shared between hosts. 

Modifications:
* Make `boot_docker_network_ipv4|6` and `boot_docker_network_aliases` host-specific.
* Add test to check if network aliases are well configured