### PR TITLE
Use a Systemd compatible seccomp profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ Docker default network is used if not specified. See networks parameter of
   (`['8080:80']`, etc.).
 * `boot_docker_volumes`: list of volumes to bind following the Docker CLI syntax
   (`['/host:/container[:ro|rw]']`).
+* `boot_docker_security_opts`: By default, use a Systemd compatible seccomp
+profile. See `security_opts` parameter of `docker_container` module.
+
 
 Example
 -------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,3 +3,8 @@ boot_docker_host: '{{ inventory_hostname }}'
 boot_docker_networks: []
 boot_docker_purge_networks: true
 boot_docker_volumes: []
+boot_docker_seccomp_url: |-
+  https://src.fedoraproject.org/rpms/docker/raw/master/f/seccomp.json
+boot_docker_seccomp: |-
+  {{ 'seccomp=' ~ lookup('url', boot_docker_seccomp_url, split_lines=False) }}
+boot_docker_security_opts: "{{ [boot_docker_seccomp] }}"

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -1,3 +1,6 @@
+import json
+import unittest
+
 import testinfra
 
 localhost = testinfra.get_host('local://')
@@ -50,3 +53,17 @@ def test_containers_aliases():
 
     assert 'container3.test' in cmd.stdout
     assert 'app3' in cmd.stdout
+
+
+def test_containers_security_opts():
+
+    cmd = localhost.run("docker info --format '{{json .SecurityOptions}}'")
+    if not json.loads(cmd.stdout):
+        raise unittest.SkipTest('seccomp not supported')
+
+    cmd = localhost.run(
+        "docker inspect -f '{{.HostConfig.SecurityOpt}}' container1-test"
+    )
+
+    assert 'unconfined' not in cmd.stdout
+    assert cmd.stdout.startswith('[seccomp={')

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,6 +14,12 @@
     - groups['all']|map('extract', hostvars, 'boot_docker_image')|
         select('defined')|list|length
 
+- name: Check if security option is supported
+  command: |-
+    {% raw %}docker info --format '{{json .SecurityOptions}}'{% endraw %}
+  register: _security_opts
+  changed_when: false
+
 - name: 'Create container for {{ boot_docker_host }}'
   docker_container:
     name: '{{ boot_docker_host }}'
@@ -24,7 +30,9 @@
     purge_networks: "{{ boot_docker_purge_networks }}"
     # These are non privileged containers running systemctl, see:
     # https://developers.redhat.com/blog/2016/09/13/running-systemd-in-a-non-privileged-container/
-    security_opts: seccomp=unconfined  # required on Debian
+    security_opts: >-
+      {{ (_security_opts.stdout and (_security_opts.stdout|from_json))|
+      ternary(boot_docker_security_opts, omit) }}
     tmpfs:
       - /tmp
       - /run


### PR DESCRIPTION
Use a Systemd compatible seccomp profile by default.

Add 3 default variables:
- `boot_docker_seccomp_url`
- `boot_docker_seccomp`
- `boot_docker_security_opts`
